### PR TITLE
Minor fixes for dependency compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/http-message": "^1",
         "psr/http-factory": "^1",
         "psr/http-client": "^1",
-        "revolt/event-loop": "^1"
+        "revolt/event-loop": "^0.1"
     },
     "require-dev": {
         "amphp/phpunit-util": "^1.4",

--- a/src/Internal/PsrInputStream.php
+++ b/src/Internal/PsrInputStream.php
@@ -2,13 +2,14 @@
 
 namespace Amp\Http\Client\Psr7\Internal;
 
-use Amp\ByteStream\InputStream;
+use Amp\ByteStream\ReadableStream;
+use Amp\Cancellation;
 use Psr\Http\Message\StreamInterface;
 
 /**
  * @internal
  */
-final class PsrInputStream implements InputStream
+final class PsrInputStream implements ReadableStream
 {
     private const DEFAULT_CHUNK_SIZE = 8192;
 
@@ -28,7 +29,7 @@ final class PsrInputStream implements InputStream
         $this->chunkSize = $chunkSize;
     }
 
-    public function read(): ?string
+    public function read(?Cancellation $cancellation = null): ?string
     {
         if (!$this->stream->isReadable()) {
             return null;
@@ -47,5 +48,20 @@ final class PsrInputStream implements InputStream
         }
 
         return $this->stream->read($this->chunkSize);
+    }
+
+    public function close(): void
+    {
+        $this->stream->close();
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->isReadable();
+    }
+
+    public function isReadable(): bool
+    {
+        return $this->stream->isReadable();
     }
 }

--- a/src/Internal/PsrInputStream.php
+++ b/src/Internal/PsrInputStream.php
@@ -57,7 +57,7 @@ final class PsrInputStream implements ReadableStream
 
     public function isClosed(): bool
     {
-        return $this->isReadable();
+        return !$this->isReadable();
     }
 
     public function isReadable(): bool

--- a/src/Internal/PsrMessageStream.php
+++ b/src/Internal/PsrMessageStream.php
@@ -131,9 +131,7 @@ final class PsrMessageStream implements StreamInterface
 
     private function readFromStream(): string
     {
-        $data = async(function (): ?string {
-            return $this->getOpenStream()->read();
-        })->await(new TimeoutCancellation($this->timeout));
+        $data = $this->getOpenStream()->read(new TimeoutCancellation($this->timeout));
 
         if ($data === null) {
             $this->isEof = true;

--- a/src/Internal/PsrMessageStream.php
+++ b/src/Internal/PsrMessageStream.php
@@ -2,10 +2,10 @@
 
 namespace Amp\Http\Client\Psr7\Internal;
 
-use Amp\ByteStream\InputStream;
-use Amp\TimeoutCancellationToken;
+use Amp\ByteStream\ReadableStream;
+use Amp\TimeoutCancellation;
 use Psr\Http\Message\StreamInterface;
-use function Amp\coroutine;
+use function Amp\async;
 
 /**
  * @internal
@@ -14,7 +14,7 @@ final class PsrMessageStream implements StreamInterface
 {
     private const DEFAULT_TIMEOUT = 5000;
 
-    private ?InputStream $stream;
+    private ?ReadableStream $stream;
 
     private int $timeout;
 
@@ -22,7 +22,7 @@ final class PsrMessageStream implements StreamInterface
 
     private bool $isEof = false;
 
-    public function __construct(InputStream $stream, int $timeout = self::DEFAULT_TIMEOUT)
+    public function __construct(ReadableStream $stream, int $timeout = self::DEFAULT_TIMEOUT)
     {
         $this->stream = $stream;
         $this->timeout = $timeout;
@@ -120,7 +120,7 @@ final class PsrMessageStream implements StreamInterface
         throw new \RuntimeException("Source stream is not writable");
     }
 
-    private function getOpenStream(): InputStream
+    private function getOpenStream(): ReadableStream
     {
         if ($this->stream === null) {
             throw new \RuntimeException("Stream is closed");
@@ -131,9 +131,9 @@ final class PsrMessageStream implements StreamInterface
 
     private function readFromStream(): string
     {
-        $data = coroutine(function (): ?string {
+        $data = async(function (): ?string {
             return $this->getOpenStream()->read();
-        })->await(new TimeoutCancellationToken($this->timeout));
+        })->await(new TimeoutCancellation($this->timeout));
 
         if ($data === null) {
             $this->isEof = true;

--- a/src/Internal/PsrStreamBody.php
+++ b/src/Internal/PsrStreamBody.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Client\Psr7\Internal;
 
-use Amp\ByteStream\InputStream;
+use Amp\ByteStream\ReadableStream;
 use Amp\Http\Client\RequestBody;
 use Psr\Http\Message\StreamInterface;
 
@@ -18,7 +18,7 @@ final class PsrStreamBody implements RequestBody
         $this->stream = $stream;
     }
 
-    public function createBodyStream(): InputStream
+    public function createBodyStream(): ReadableStream
     {
         return new PsrInputStream($this->stream);
     }

--- a/src/PsrAdapter.php
+++ b/src/PsrAdapter.php
@@ -3,6 +3,7 @@
 namespace Amp\Http\Client\Psr7;
 
 use Amp\ByteStream\InputStream;
+use Amp\ByteStream\ReadableStream;
 use Amp\Http\Client\HttpException;
 use Amp\Http\Client\Psr7\Internal\PsrInputStream;
 use Amp\Http\Client\Psr7\Internal\PsrStreamBody;
@@ -77,7 +78,7 @@ final class PsrAdapter
         return $psrResponse;
     }
 
-    private function copyToPsrStream(InputStream $source, StreamInterface $target): void
+    private function copyToPsrStream(ReadableStream $source, StreamInterface $target): void
     {
         while (null !== $data = $source->read()) {
             $target->write($data);

--- a/test/Internal/PsrMessageStreamTest.php
+++ b/test/Internal/PsrMessageStreamTest.php
@@ -8,8 +8,8 @@ use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\ReadableStream;
 use Amp\ByteStream\StreamException;
 use Amp\Cancellation;
-use Amp\Pipeline\AsyncGenerator;
 use PHPUnit\Framework\TestCase;
+use function Amp\Pipeline\fromIterable;
 
 /**
  * @covers \Amp\Http\Client\Psr7\Internal\PsrMessageStream
@@ -225,7 +225,7 @@ class PsrMessageStreamTest extends TestCase
         string $expectedFirstResult,
         string $expectedSecondResult
     ): void {
-        $inputStream = new IterableStream(new AsyncGenerator(function () use ($secondChunk, $firstChunk) {
+        $inputStream = new IterableStream(fromIterable(function () use ($secondChunk, $firstChunk) {
             yield $firstChunk;
             yield $secondChunk;
         }));

--- a/test/Internal/PsrMessageStreamTest.php
+++ b/test/Internal/PsrMessageStreamTest.php
@@ -2,6 +2,7 @@
 
 namespace Amp\Http\Client\Psr7\Internal;
 
+use Amp\ByteStream\IterableStream;
 use Amp\ByteStream\PendingReadError;
 use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\ReadableStream;
@@ -224,35 +225,10 @@ class PsrMessageStreamTest extends TestCase
         string $expectedFirstResult,
         string $expectedSecondResult
     ): void {
-        $inputStream = new class(new AsyncGenerator(function () use ($secondChunk, $firstChunk) {
+        $inputStream = new IterableStream(new AsyncGenerator(function () use ($secondChunk, $firstChunk) {
             yield $firstChunk;
             yield $secondChunk;
-        }))  implements ReadableStream {
-
-            public function __construct(private AsyncGenerator $generator)
-            {
-            }
-
-            public function close(): void
-            {
-                $this->generator->dispose();
-            }
-
-            public function isClosed(): bool
-            {
-                return $this->generator->isComplete();
-            }
-
-            public function read(?Cancellation $cancellation = null): ?string
-            {
-                return $this->generator->continue();
-            }
-
-            public function isReadable(): bool
-            {
-                return !$this->isClosed();
-            }
-        };
+        }));
 
         $requestStream = new PsrMessageStream($inputStream);
 

--- a/test/PsrAdapterTest.php
+++ b/test/PsrAdapterTest.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Client\Psr7;
 
-use Amp\ByteStream\InMemoryStream;
+use Amp\ByteStream\ReadableBuffer;
 use Amp\Http\Client\HttpException;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\RequestBody;
@@ -173,7 +173,7 @@ class PsrAdapterTest extends TestCase
             Status::OK,
             null,
             [],
-            new InMemoryStream(''),
+            new ReadableBuffer(''),
             new Request('')
         );
 
@@ -191,7 +191,7 @@ class PsrAdapterTest extends TestCase
             Status::NOT_FOUND,
             null,
             [],
-            new InMemoryStream(''),
+            new ReadableBuffer(''),
             new Request('')
         );
 
@@ -209,7 +209,7 @@ class PsrAdapterTest extends TestCase
             Status::OK,
             'a',
             [],
-            new InMemoryStream(''),
+            new ReadableBuffer(''),
             new Request('')
         );
 
@@ -227,7 +227,7 @@ class PsrAdapterTest extends TestCase
             Status::OK,
             null,
             ['a' => 'b', 'c' => ['d', 'e']],
-            new InMemoryStream(''),
+            new ReadableBuffer(''),
             new Request('')
         );
 
@@ -245,7 +245,7 @@ class PsrAdapterTest extends TestCase
             Status::OK,
             null,
             [],
-            new InMemoryStream('body_content'),
+            new ReadableBuffer('body_content'),
             new Request('')
         );
 
@@ -289,7 +289,7 @@ class PsrAdapterTest extends TestCase
             Status::OK,
             null,
             [],
-            new InMemoryStream(''),
+            new ReadableBuffer(''),
             new Request('')
         );
 


### PR DESCRIPTION
A couple minor fixes for the v2 branch:
- Depends on revolt/event-loop ^0.1 instead of ^1 (other projects use ^1 so composer refused to install the "conflicting" packages)
- `coroutine()` => `async()`, `TimeoutCancellationToken` => `TimeoutCancellation` as per https://github.com/amphp/amp/releases/tag/v3.0.0-beta.1
- Various renames as per https://github.com/amphp/byte-stream/releases/tag/v2.0.0-beta.1