### PR TITLE
Update event-loop to 0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/http-message": "^1",
         "psr/http-factory": "^1",
         "psr/http-client": "^1",
-        "revolt/event-loop": "^0.1"
+        "revolt/event-loop": "^0.2"
     },
     "require-dev": {
         "amphp/phpunit-util": "^1.4",

--- a/test/Internal/PsrMessageStreamTest.php
+++ b/test/Internal/PsrMessageStreamTest.php
@@ -2,14 +2,14 @@
 
 namespace Amp\Http\Client\Psr7\Internal;
 
-use Amp\ByteStream\IterableStream;
 use Amp\ByteStream\PendingReadError;
 use Amp\ByteStream\ReadableBuffer;
+use Amp\ByteStream\ReadableIterableStream;
 use Amp\ByteStream\ReadableStream;
 use Amp\ByteStream\StreamException;
 use Amp\Cancellation;
+use Amp\Pipeline\Pipeline;
 use PHPUnit\Framework\TestCase;
-use function Amp\Pipeline\fromIterable;
 
 /**
  * @covers \Amp\Http\Client\Psr7\Internal\PsrMessageStream
@@ -225,7 +225,7 @@ class PsrMessageStreamTest extends TestCase
         string $expectedFirstResult,
         string $expectedSecondResult
     ): void {
-        $inputStream = new IterableStream(fromIterable(function () use ($secondChunk, $firstChunk) {
+        $inputStream = new ReadableIterableStream(Pipeline::fromIterable(function () use ($secondChunk, $firstChunk) {
             yield $firstChunk;
             yield $secondChunk;
         }));


### PR DESCRIPTION
Updates event-loop to `^0.2` - also fix failing tests caused by https://github.com/amphp/byte-stream/releases/tag/v2.0.0-beta.4 (fail when upgraded to ^0.2 because Composer is allowed to install byte-stream beta4).