### PR TITLE
Fix compatibility with amphp/http-client beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,11 @@
             "email": "zoohie@gmail.com"
         }
     ],
-    "minimum-stability": "beta",
-    "prefer-stable": true,
     "require": {
         "php": ">=8.1",
         "amphp/amp": "^3",
         "amphp/byte-stream": "^2",
-        "amphp/http-client": "^5",
+        "amphp/http-client": "^v5.0.0-beta.11",
         "psr/http-message": "^1",
         "psr/http-factory": "^1",
         "psr/http-client": "^1",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
             "email": "zoohie@gmail.com"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "beta",
     "prefer-stable": true,
     "require": {
         "php": ">=8.1",
@@ -31,7 +31,7 @@
         "psr/http-message": "^1",
         "psr/http-factory": "^1",
         "psr/http-client": "^1",
-        "revolt/event-loop": "^0.2"
+        "revolt/event-loop": "^1"
     },
     "require-dev": {
         "amphp/phpunit-util": "^1.4",

--- a/src/Internal/PsrInputStream.php
+++ b/src/Internal/PsrInputStream.php
@@ -3,14 +3,16 @@
 namespace Amp\Http\Client\Psr7\Internal;
 
 use Amp\ByteStream\ReadableStream;
+use Amp\ByteStream\ReadableStreamIteratorAggregate;
 use Amp\Cancellation;
 use Psr\Http\Message\StreamInterface;
 
 /**
  * @internal
  */
-final class PsrInputStream implements ReadableStream
+final class PsrInputStream implements ReadableStream, \IteratorAggregate
 {
+    use ReadableStreamIteratorAggregate;
     public const DEFAULT_CHUNK_SIZE = 8192;
 
     private StreamInterface $stream;

--- a/src/Internal/PsrStreamBody.php
+++ b/src/Internal/PsrStreamBody.php
@@ -3,13 +3,13 @@
 namespace Amp\Http\Client\Psr7\Internal;
 
 use Amp\ByteStream\ReadableStream;
-use Amp\Http\Client\RequestBody;
+use Amp\Http\Client\HttpContent;
 use Psr\Http\Message\StreamInterface;
 
 /**
  * @internal
  */
-final class PsrStreamBody implements RequestBody
+final class PsrStreamBody implements HttpContent
 {
     private StreamInterface $stream;
 
@@ -18,18 +18,18 @@ final class PsrStreamBody implements RequestBody
         $this->stream = $stream;
     }
 
-    public function createBodyStream(): ReadableStream
+    public function getContent(): ReadableStream
     {
         return new PsrInputStream($this->stream);
     }
 
-    public function getBodyLength(): ?int
+    public function getContentLength(): ?int
     {
         return $this->stream->getSize() ?? -1;
     }
 
-    public function getHeaders(): array
+    public function getContentType(): ?string
     {
-        return [];
+        return null;
     }
 }

--- a/src/Internal/PsrStreamBody.php
+++ b/src/Internal/PsrStreamBody.php
@@ -25,7 +25,7 @@ final class PsrStreamBody implements HttpContent
 
     public function getContentLength(): ?int
     {
-        return $this->stream->getSize() ?? -1;
+        return $this->stream->getSize();
     }
 
     public function getContentType(): ?string

--- a/src/PsrAdapter.php
+++ b/src/PsrAdapter.php
@@ -53,7 +53,7 @@ final class PsrAdapter
     {
         $target = $this->toPsrRequestWithoutBody($source, $protocolVersion);
 
-        $this->copyToPsrStream($source->getBody()->createBodyStream(), $target->getBody());
+        $this->copyToPsrStream($source->getBody()->getContent(), $target->getBody());
 
         return $target;
     }
@@ -68,7 +68,7 @@ final class PsrAdapter
         $psrResponse = $this->responseFactory->createResponse($response->getStatus(), $response->getReason())
             ->withProtocolVersion($response->getProtocolVersion());
 
-        foreach ($response->getRawHeaders() as [$headerName, $headerValue]) {
+        foreach ($response->getHeaderPairs() as [$headerName, $headerValue]) {
             $psrResponse = $psrResponse->withAddedHeader($headerName, $headerValue);
         }
 
@@ -92,7 +92,7 @@ final class PsrAdapter
     ): PsrRequest {
         $target = $this->requestFactory->createRequest($source->getMethod(), $source->getUri());
 
-        foreach ($source->getRawHeaders() as [$headerName, $headerValue]) {
+        foreach ($source->getHeaderPairs() as [$headerName, $headerValue]) {
             $target = $target->withAddedHeader($headerName, $headerValue);
         }
 

--- a/test/Internal/PsrStreamBodyTest.php
+++ b/test/Internal/PsrStreamBodyTest.php
@@ -16,7 +16,6 @@ class PsrStreamBodyTest extends TestCase
      * @param int|null $size
      * @param int      $expectedSize
      *
-     * @return \Generator
      * @dataProvider providerBodyLength
      */
     public function testGetBodyLengthReturnsValueFromStream(?int $size, int $expectedSize): void
@@ -26,7 +25,7 @@ class PsrStreamBodyTest extends TestCase
 
         $body = new PsrStreamBody($stream);
 
-        self::assertSame($expectedSize, $body->getBodyLength());
+        self::assertSame($expectedSize, $body->getContentLength());
     }
 
     public function providerBodyLength(): array
@@ -38,12 +37,12 @@ class PsrStreamBodyTest extends TestCase
         ];
     }
 
-    public function testGetHeadersReturnsEmptyList(): void
+    public function testContentTypeIsNull(): void
     {
         $stream = $this->createMock(StreamInterface::class);
         $body = new PsrStreamBody($stream);
 
-        self::assertSame([], $body->getHeaders());
+        self::assertSame(null, $body->getContentType());
     }
 
     public function testCreateBodyStreamResultReadsFromOriginalStream(): void
@@ -51,6 +50,6 @@ class PsrStreamBodyTest extends TestCase
         $stream = (new StreamFactory())->createStream('body_content');
         $body = new PsrStreamBody($stream);
 
-        self::assertSame('body_content', buffer($body->createBodyStream()));
+        self::assertSame('body_content', buffer($body->getContent()));
     }
 }

--- a/test/Internal/PsrStreamBodyTest.php
+++ b/test/Internal/PsrStreamBodyTest.php
@@ -14,11 +14,11 @@ class PsrStreamBodyTest extends TestCase
 {
     /**
      * @param int|null $size
-     * @param int      $expectedSize
+     * @param int|null $expectedSize
      *
      * @dataProvider providerBodyLength
      */
-    public function testGetBodyLengthReturnsValueFromStream(?int $size, int $expectedSize): void
+    public function testGetBodyLengthReturnsValueFromStream(?int $size, ?int $expectedSize): void
     {
         $stream = $this->createMock(StreamInterface::class);
         $stream->method('getSize')->willReturn($size);
@@ -33,7 +33,7 @@ class PsrStreamBodyTest extends TestCase
         return [
             'Stream provides zero size' => [0, 0],
             'Stream provides positive size' => [1, 1],
-            'Stream doesn\'t provide its size' => [null, -1],
+            'Stream doesn\'t provide its size' => [null, null],
         ];
     }
 

--- a/test/PsrAdapterTest.php
+++ b/test/PsrAdapterTest.php
@@ -3,11 +3,11 @@
 namespace Amp\Http\Client\Psr7;
 
 use Amp\ByteStream\ReadableBuffer;
+use Amp\Http\Client\HttpContent;
 use Amp\Http\Client\HttpException;
 use Amp\Http\Client\Request;
-use Amp\Http\Client\RequestBody;
 use Amp\Http\Client\Response;
-use Amp\Http\Status;
+use Amp\Http\HttpStatus;
 use Laminas\Diactoros\Request as PsrRequest;
 use Laminas\Diactoros\RequestFactory;
 use Laminas\Diactoros\Response as PsrResponse;
@@ -170,7 +170,7 @@ class PsrAdapterTest extends TestCase
 
         $source = new Response(
             '2',
-            Status::OK,
+            HttpStatus::OK,
             null,
             [],
             new ReadableBuffer(''),
@@ -188,7 +188,7 @@ class PsrAdapterTest extends TestCase
 
         $source = new Response(
             '1.1',
-            Status::NOT_FOUND,
+            HttpStatus::NOT_FOUND,
             null,
             [],
             new ReadableBuffer(''),
@@ -197,7 +197,7 @@ class PsrAdapterTest extends TestCase
 
         $target = $adapter->toPsrResponse($source);
 
-        self::assertSame(Status::NOT_FOUND, $target->getStatusCode());
+        self::assertSame(HttpStatus::NOT_FOUND, $target->getStatusCode());
     }
 
     public function testToPsrResponseReturnsResponseWithEqualReason(): void
@@ -206,7 +206,7 @@ class PsrAdapterTest extends TestCase
 
         $source = new Response(
             '1.1',
-            Status::OK,
+            HttpStatus::OK,
             'a',
             [],
             new ReadableBuffer(''),
@@ -224,7 +224,7 @@ class PsrAdapterTest extends TestCase
 
         $source = new Response(
             '1.1',
-            Status::OK,
+            HttpStatus::OK,
             null,
             ['a' => 'b', 'c' => ['d', 'e']],
             new ReadableBuffer(''),
@@ -242,7 +242,7 @@ class PsrAdapterTest extends TestCase
 
         $source = new Response(
             '1.1',
-            Status::OK,
+            HttpStatus::OK,
             null,
             [],
             new ReadableBuffer('body_content'),
@@ -286,7 +286,7 @@ class PsrAdapterTest extends TestCase
 
         $previousResponse = new Response(
             '1.1',
-            Status::OK,
+            HttpStatus::OK,
             null,
             [],
             new ReadableBuffer(''),
@@ -315,11 +315,11 @@ class PsrAdapterTest extends TestCase
     {
         $adapter = new PsrAdapter(new RequestFactory, new ResponseFactory);
 
-        $source = (new PsrResponse())->withStatus(Status::NOT_FOUND);
+        $source = (new PsrResponse())->withStatus(HttpStatus::NOT_FOUND);
 
         $target = $adapter->fromPsrResponse($source, new Request(''));
 
-        self::assertSame(Status::NOT_FOUND, $target->getStatus());
+        self::assertSame(HttpStatus::NOT_FOUND, $target->getStatus());
     }
 
     public function testFromPsrResponseReturnsResultWithEqualHeaders(): void
@@ -328,7 +328,7 @@ class PsrAdapterTest extends TestCase
 
         $source = new PsrResponse(
             'php://memory',
-            Status::OK,
+            HttpStatus::OK,
             ['a' => 'b', 'c' => ['d', 'e']]
         );
 
@@ -351,9 +351,9 @@ class PsrAdapterTest extends TestCase
         self::assertSame('body_content', $target->getBody()->buffer());
     }
 
-    private function readBody(RequestBody $body): string
+    private function readBody(HttpContent $body): string
     {
-        $stream = $body->createBodyStream();
+        $stream = $body->getContent();
 
         return buffer($stream);
     }


### PR DESCRIPTION
Fixes compatibility with the newest amphp/http-client release by updating revolt/event-loop to ^1.  Also sets the minimum stability to beta as all upstream dependencies have reached beta stage.