### PR TITLE
Added `GuzzleHttpClientBuilder` to build an `HttpClient` with Guzzle 7 defaults

### DIFF
--- a/src/GuzzleHttpClientBuilder.php
+++ b/src/GuzzleHttpClientBuilder.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Amp\Http\Client\Psr7;
+
+use Amp\Http\Client\HttpClient;
+use Amp\Http\Client\HttpClientBuilder;
+use GuzzleHttp\RedirectMiddleware;
+
+/**
+ * Builds an HttpClient with Guzzle 7 defaults applied.
+ */
+final class GuzzleHttpClientBuilder
+{
+    public function build(): HttpClient
+    {
+        return $this->createPrototype()->build();
+    }
+
+    public function createPrototype(): HttpClientBuilder
+    {
+        return (new HttpClientBuilder())
+            ->followRedirects(RedirectMiddleware::$defaultSettings['max'])
+            ->retry(0); // Guzzle doesn't support retries. Sad!
+    }
+}

--- a/test/TestTools.php
+++ b/test/TestTools.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Amp\Http\Client\Psr7;
+
+use Amp\Http\Client\ApplicationInterceptor;
+use Amp\Http\Client\DelegateHttpClient;
+use ReflectionProperty;
+
+final class TestTools
+{
+    public static function readProperty(object $object, string $property): mixed
+    {
+        return (new ReflectionProperty($object, $property))->getValue($object);
+    }
+
+    public static function walkHttpClientStack(DelegateHttpClient $httpClient): \Generator
+    {
+        while ($httpClient) {
+            try {
+                yield $httpClient = self::readProperty($httpClient, 'httpClient');
+            } catch (\ReflectionException) {
+                return;
+            }
+        }
+    }
+
+    public static function findApplicationInterceptor(
+        DelegateHttpClient $httpClient,
+        string $interceptorClass,
+    ): ?ApplicationInterceptor {
+        foreach (self::walkHttpClientStack($httpClient) as $httpClient) {
+            try {
+                $interceptor = self::readProperty($httpClient, 'interceptor');
+            } catch (\ReflectionException) {
+                return null;
+            }
+
+            if ($interceptor instanceof $interceptorClass) {
+                return $interceptor;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This adds `GuzzleHttpClientBuilder`, a new `HttpClient` builder, so the caller can easily use Guzzle defaults as the base for their own modifications instead of always starting from Amp defaults. This new builder is now consumed by `GuzzleHandlerAdapter` to apply the correct `ApplicationInterceptor` defaults. Additional changes are made to the `__invoke` body to apply request-time defaults.

In particular the following defaults are changed.

| | Before | After |
|-:|-|-|
| **Follow redirects** | Disabled | Enabled (5) |
| **Retry requests** | Enabled (2) | Disabled |
| **Transfer timeout** | 10 s | Disabled |
| **Inactivity timeout** | 10 s | Disabled |
| **Connection timeout** | 10 s | Disabled |

The constructor had to be changed to accept the more generalized type, `DelegateHttpClient` rather than `HttpClient`, purely for testing purposes, because we cannot mock a final class. It is supposed this does not harm the application domain in any way, however.

It should be noted that testing a bunch of final classes with private properties and no accessor methods was an absolute ballache, as you can presumably intuit from how hacky the tests are, but this is the best I could do. I don't think it turned out too bad, all things considered.