### PR TITLE
Pass response body size from Content-Length header to PsrMessageStream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -50,7 +50,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-${{ matrix.composer-flags }}

--- a/src/Internal/PsrMessageStream.php
+++ b/src/Internal/PsrMessageStream.php
@@ -18,7 +18,7 @@ final class PsrMessageStream implements StreamInterface
 
     private int $position = 0;
 
-    public function __construct(private readonly ReadableStream $source)
+    public function __construct(private readonly ReadableStream $source, private readonly ?int $size = null)
     {
     }
 
@@ -64,7 +64,7 @@ final class PsrMessageStream implements StreamInterface
 
     public function getSize(): ?int
     {
-        return null;
+        return $this->size;
     }
 
     public function isReadable(): bool

--- a/src/PsrAdapter.php
+++ b/src/PsrAdapter.php
@@ -74,7 +74,10 @@ final class PsrAdapter
             $psrResponse = $psrResponse->withAddedHeader($headerName, $headerValue);
         }
 
-        return $psrResponse->withBody(new PsrMessageStream($response->getBody()));
+        $contentLength = $response->getHeader('Content-Length');
+        $size = $contentLength === null ? null : \max(0, (int) $contentLength);
+
+        return $psrResponse->withBody(new PsrMessageStream($response->getBody(), $size));
     }
 
     /**


### PR DESCRIPTION
Currently, PsrMessageStream is unaware of the underlying body size. However, in some cases, knowing the body size can be useful or even required. When the Content-Length header is present in the response, the body size can be determined and passed to the PsrMessageStream constructor at creation time.