### PR TITLE
Fix behavioral incompatibility between PsrMessageStream and StreamInterface

### DIFF
--- a/src/Internal/PsrMessageStream.php
+++ b/src/Internal/PsrMessageStream.php
@@ -16,6 +16,8 @@ final class PsrMessageStream implements StreamInterface
 
     private bool $isEof = false;
 
+    private bool $isClosed = false;
+
     private int $position = 0;
 
     public function __construct(private readonly ReadableStream $source, private readonly ?int $size = null)
@@ -32,6 +34,7 @@ final class PsrMessageStream implements StreamInterface
         $this->source->close();
         $this->buffer = '';
         $this->isEof = true;
+        $this->isClosed = true;
     }
 
     public function detach(): void
@@ -46,6 +49,10 @@ final class PsrMessageStream implements StreamInterface
 
     public function getContents(): string
     {
+        if ($this->isClosed) {
+            throw new \RuntimeException("Stream is closed");
+        }
+
         $buffer = $this->buffer;
         $this->buffer = '';
 
@@ -69,7 +76,7 @@ final class PsrMessageStream implements StreamInterface
 
     public function isReadable(): bool
     {
-        return !$this->eof();
+        return !$this->isClosed;
     }
 
     public function isSeekable(): bool
@@ -84,7 +91,7 @@ final class PsrMessageStream implements StreamInterface
 
     public function read(int $length): string
     {
-        if ($this->eof()) {
+        if ($this->isClosed) {
             throw new \RuntimeException("Stream is closed");
         }
 

--- a/src/Internal/PsrMessageStream.php
+++ b/src/Internal/PsrMessageStream.php
@@ -37,9 +37,11 @@ final class PsrMessageStream implements StreamInterface
         $this->isClosed = true;
     }
 
-    public function detach(): void
+    public function detach()
     {
         $this->close();
+
+        return null;
     }
 
     public function eof(): bool

--- a/test/Internal/PsrMessageStreamTest.php
+++ b/test/Internal/PsrMessageStreamTest.php
@@ -93,8 +93,7 @@ class PsrMessageStreamTest extends TestCase
         self::assertSame('', $requestStream->read(8192));
         self::assertSame(6, $requestStream->tell());
         self::assertTrue($requestStream->eof());
-        self::assertFalse($requestStream->isReadable());
-
+        self::assertTrue($requestStream->isReadable());
     }
 
     public function testRewindThrowsException(): void

--- a/test/PsrAdapterTest.php
+++ b/test/PsrAdapterTest.php
@@ -267,7 +267,7 @@ class PsrAdapterTest extends TestCase
 
         self::assertSame('content', $body->read(8192));
         self::assertTrue($body->eof());
-        self::assertFalse($body->isReadable());
+        self::assertTrue($body->isReadable());
     }
 
     public function testFromPsrResponseWithRequestReturnsResultWithSameRequest(): void


### PR DESCRIPTION
This merge request fixes a behavioral incompatibility between `PsrMessageStream` and `Psr\Http\Message\StreamInterface`.
The `read()` method incorrectly throw an exception upon reaching the end of the stream. According to the interface contract, it should return an empty string instead.  [See StreamInterface docs here.](https://github.com/php-fig/http-message/blob/402d35bcb92c70c026d1a6a9883f06b2ead23d71/src/StreamInterface.php#L130)
The `isReadable()` method incorrectly returned false at end of file, whereas it should continue to return true.  See the default implementation of [GuzzleHttp\Psr7\Stream.php](https://github.com/guzzle/psr7/blob/2.8/src/Stream.php) - it stays readable by reaching end of file.

These issues caused compatibility problems with components relying on `Psr\Http\Message\StreamInterface` - for example, Guzzle's [CachingStream](https://github.com/guzzle/psr7/blob/2.7/src/CachingStream.php) fails when used with `PsrMessageStream` now.